### PR TITLE
haproxy 1.8 and other goodies 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,8 +28,7 @@ haproxy_timeouts:
   - { type: "client",  value: 50000 }
   - { type: "server",  value: 50000 }
 
-haproxy_additional_defaults:
-  - default-server init-addr last,libc,none
+haproxy_additional_defaults: []
 
 haproxy_forwardfor: False
 haproxy_bind_on_non_local: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-haproxy_usa_ppa: False
+haproxy_use_ppa: False
 haproxy_ppa_repo: ppa:vbernat/haproxy-1.8
 
 haproxy_stats_socket: "/run/haproxy/admin.sock"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+haproxy_usa_ppa: False
+haproxy_ppa_repo: ppa:vbernat/haproxy-1.8
+
 haproxy_stats_socket: "/run/haproxy/admin.sock"
 haproxy_stats_enabled: True
 haproxy_ssl_enabled: False
@@ -24,6 +27,9 @@ haproxy_timeouts:
   - { type: "connect", value: 5000 }
   - { type: "client",  value: 50000 }
   - { type: "server",  value: 50000 }
+
+haproxy_additional_defaults:
+  - default-server init-addr last,libc,none
 
 haproxy_forwardfor: False
 haproxy_bind_on_non_local: True

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,7 @@
     repo: "{{ haproxy_ppa_repo }}"
     update_cache: yes
     validate_certs: no
-  when: ansible_pkg_mgr == 'apt' and haproxy_usa_ppa == True
+  when: ansible_pkg_mgr == 'apt' and haproxy_use_ppa == True
 
 - name: Install HAProxy Packages
   package:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,11 @@
 ---
+- name: Add repository | [Debian/Ubuntu]
+  apt_repository:
+    repo: "{{ haproxy_ppa_repo }}"
+    update_cache: yes
+    validate_certs: no
+  when: ansible_pkg_mgr == 'apt' and haproxy_usa_ppa == True
+
 - name: Install HAProxy Packages
   package:
     name: "{{ item }}"

--- a/tasks/metrics.yml
+++ b/tasks/metrics.yml
@@ -24,6 +24,7 @@
     src: "/opt/haproxy_exporter-{{ haproxy_exporter_version }}.linux-amd64"
     dest: /opt/haproxy_exporter
     state: link
+    force: yes
 
 - name: Copy the HAProxy Exporter systemd service file
   template:

--- a/tasks/metrics.yml
+++ b/tasks/metrics.yml
@@ -17,7 +17,7 @@
     src: "/tmp/haproxy_exporter-{{ haproxy_exporter_version }}.tar.gz"
     dest: "/opt/"
     copy: no
-    creates: "/opt/haproxy_exporter"
+    creates: "/opt/haproxy_exporter-{{ haproxy_exporter_version }}.linux-amd64"
 
 - name: Create a symlink for /opt/haproxy_exporter
   file:

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -20,6 +20,9 @@ defaults
     mode    http
     option  httplog
     option  dontlognull
+{% for def in haproxy_additional_defaults |default([]) %}
+    {{ def }}
+{% endfor %}
 {% if haproxy_forwardfor %}
     option  forwardfor
 {% endif %}

--- a/templates/haproxy_exporter.service.j2
+++ b/templates/haproxy_exporter.service.j2
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 PIDFile=/var/run/haproxy_exporter.pid
-ExecStart=/opt/haproxy_exporter/haproxy_exporter {% for flag, flag_value in haproxy_exporter_config_flags.iteritems() %}-{{ flag }}={{ flag_value }} {% endfor %}
+ExecStart=/opt/haproxy_exporter/haproxy_exporter {% for flag, flag_value in haproxy_exporter_config_flags.iteritems() %}{{ '-' if (haproxy_exporter_version |version_compare('0.8.0', '>=')) else ''}}-{{ flag }}={{ flag_value }} {% endfor %}
 
 SyslogIdentifier=haproxy_exporter
 Restart=always

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -36,3 +36,7 @@
 {% for srv in service.servers | default([]) %}
     server {{ srv.name }} {{ srv.address }} {{ srv.options | default('maxconn 15') }}
 {% endfor %}
+{# SERVICE TEMPLATES #}
+{% for tpl in service.templates | default([]) %}
+    server-template {{ tpl.prefix |default('srv') }} {{ tpl.range |default(5) }} {{ tpl.fqdn }}:{{ tpl.port |default(80) }} {{ tpl.params | default('check maxconn 15') }}
+{% endfor %}


### PR DESCRIPTION
hello,

i've been using this role with customisation for a while and wanted to share. 

- added different version support with ppa repository ( only enabled when `haproxy_usa_ppa: True` )
- added `haproxy_additional_defaults` to support additional default options
- fix haproxy exporter requires double dash for versions >= 0.8.0
- fix exporter symlink when haproxy exporter version change happen 
- added `service.templates` variables to support [server templates](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4-server-template)
